### PR TITLE
fix: 'View' is ambiguous for type lookup in this context

### DIFF
--- a/IPA Chat/ContentView.swift
+++ b/IPA Chat/ContentView.swift
@@ -193,12 +193,12 @@ class AudioManager: ObservableObject {
 
 struct SettingsView: SwiftUI.View {
     @ObservedObject var audioManager: AudioManager
-    @Binding var selectedLanguage: String
+    @SwiftUI.Binding var selectedLanguage: String
     var languages = ["English-GB", "French"]
     var groupedVoices: [String: [VoiceWrapper]] = voicesByLanguage()
-    @Binding var phonemes: [Phoneme]
+    @SwiftUI.Binding var phonemes: [Phoneme]
     
-    var body: some View {
+    var body: some SwiftUI.View {
         Form {
             Toggle("Speak utterance as selected", isOn: $audioManager.shouldSpeakFullUtterance)
             
@@ -238,7 +238,7 @@ struct SettingsView: SwiftUI.View {
     
 }
 
-struct ContentView: View {
+struct ContentView: SwiftUI.View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @ObservedObject var audioManager = AudioManager()
     @State var isEditMode: Bool = false
@@ -360,7 +360,7 @@ struct ContentView: View {
     }
     
     
-    var body: some View {
+    var body: some SwiftUI.View {
         GeometryReader { geometry in
             NavigationView {
                 VStack {


### PR DESCRIPTION
There is also a View declaration in SQLite, 
`public struct View: SchemaType`
importing SwiftUI and SQLite in the same file will cause naming conflicts, and the compiler cannot identify which View you are using.

You have to specify the module from which to lookup object type. Call `SwiftUI.View` `@SwiftUI.Binding` `SQLite.View`

Or You can refactor `ContentView.swift` to put the DB related operations in an extra file such as `DB.swift`, so you don't have to `import SQLite` in `ContentView.swift`